### PR TITLE
Set Content-Type to JSON for JSON responses

### DIFF
--- a/classes/Kohana/Controller/Tart/Typeahead.php
+++ b/classes/Kohana/Controller/Tart/Typeahead.php
@@ -36,6 +36,7 @@ abstract class Kohana_Controller_Tart_Typeahead extends Controller {
 			$response = array_merge($response, $model_response);
 		}
 
+		$this->response->headers('Content-Type', 'application/json');
 		$this->response->body(json_encode($response));
 	}
 
@@ -46,6 +47,8 @@ abstract class Kohana_Controller_Tart_Typeahead extends Controller {
 		$names = Jam::all($model)
 			->where(':name_key', 'LIKE', "%{$q}%")
 			->limit(5);
+
+		$this->response->headers('Content-Type', 'application/json');
 		$this->response->body(json_encode($names->as_array(NULL, ':name_key')));
 	}
 


### PR DESCRIPTION
Set this header:

```
Content-Type: application/json
```

so when jQuery loads the data from the AJAX it converts it to an array of objects.
Otherwise there is an error when accessing the name property.
