### PR TITLE
Show exact time in timestamp title attribute

### DIFF
--- a/classes/Kohana/Tart/Column.php
+++ b/classes/Kohana/Tart/Column.php
@@ -148,7 +148,7 @@ abstract class Kohana_Tart_Column extends Tart_Group_Item {
 				return '-';
 			
 			$time = is_numeric($value) ? $value : strtotime($value);
-			return '<span title="'.date('j M Y', $time).'">'.Tart_Html::date_span($time).'</span>';
+			return '<span title="'.date('j M Y H:i:s', $time).'">'.Tart_Html::date_span($time).'</span>';
 		}
 		elseif ($field instanceof Jam_Field_Weblink)
 		{

--- a/tests/tests/columnTest.php
+++ b/tests/tests/columnTest.php
@@ -74,7 +74,7 @@ class Jamtart_ColumnTest extends PHPUnit_Framework_TestCase {
 
 		$rendered = $column->name('created_at')->render();
 		$year_diff = ( (int) date('Y')) - ( (int) date('Y', $this->city->created_at));
-		$this->assertEquals('<span title="1 Jan 2000">'.$year_diff.' years ago</span>', $rendered);
+		$this->assertEquals('<span title="1 Jan 2000 14:30:00">'.$year_diff.' years ago</span>', $rendered);
 
 		$rendered = $column->name('url')->render();
 		$this->assertEquals('http://example.com/ths-is-a-ve…&nbsp;<a href="http://example.com/ths-is-a-very-lon-url/and-should-be-shortend" target="_blank"><i class="icon-share-alt"></i></a>', $rendered);


### PR DESCRIPTION
It is useful to have the exact time especially for recent events when the text
is like 1 day ago.