### PR TITLE
Use button[type=button] in multiselect

### DIFF
--- a/classes/Kohana/Jam/Form/Tart/General.php
+++ b/classes/Kohana/Jam/Form/Tart/General.php
@@ -412,7 +412,7 @@ abstract class Kohana_Jam_Form_Tart_General extends Jam_Form_General {
 			
 				if ($options['new_button'])
 				{
-					$h('button', array('class' => 'btn', 'data-remoteselect-new' => $options['model']), $options['new_button']);
+					$h('button', array('type' => 'button', 'class' => 'btn', 'data-remoteselect-new' => $options['model']), $options['new_button']);
 				}
 
 				if ($options['list'])


### PR DESCRIPTION
If the `new_button` option is supplied to the `multiselect` form widget and the template contains any inputs, pressing Enter while focused an input would actually activate the new button. The browser sets it as the default submit button for the form since it is above the "Save changes" one.

The solution is to have a `type="button"` attribute.
