### PR TITLE
Change all checkboxes, no matter their name

### DIFF
--- a/web/js/general.js
+++ b/web/js/general.js
@@ -75,7 +75,7 @@ $(function(){
 	});
 
 	$('body').on('change', 'input[name="all"]', function(e){
-		$(this).closest('table').find('tbody > tr > td:first-child input[name="id[]"]').prop('checked', $(this).prop('checked'));
+		$(this).closest('table').find('tbody > tr > td:first-child input[type="checkbox"]').prop('checked', $(this).prop('checked'));
 	});
 
 	$('body').on('click', '[data-toggle="modal"]', function(e) {


### PR DESCRIPTION
Changing the [name="all"] checkbox in a table should check every checkbox in
the first column. It should not matter if their name is "id[]".

This is very useful for nested tables, because usually there would be nested 
forms there as well.
