### PR TITLE
change form call for sort filter

### DIFF
--- a/classes/Kohana/Tart/Filter/Entry/Sort.php
+++ b/classes/Kohana/Tart/Filter/Entry/Sort.php
@@ -28,7 +28,7 @@ abstract class Kohana_Tart_Filter_Entry_Sort extends Tart_Filter_Entry {
 
 	public function render()
 	{
-		return $this->parent()->form()->row('hidden', $this->name());
+		return $this->parent()->form()->hidden($this->name());
 	}
 
 }


### PR DESCRIPTION
Prevent Sort label to being printed with hidden input. Just leave the
hidden input.
