### PR TITLE
Add workaround for images with absolute URL

### DIFF
--- a/classes/Kohana/Jam/Form/Tart/General.php
+++ b/classes/Kohana/Jam/Form/Tart/General.php
@@ -202,7 +202,12 @@ abstract class Kohana_Jam_Form_Tart_General extends Jam_Form_General {
 					{
 						$thumbnail = Arr::get($options, 'thumbnail');
 
-						$h('img', array('src' => URL::site($self->object()->$name->url($thumbnail, TRUE))));
+						$img_url = $self->object()->$name->url($thumbnail);
+						$h('img', array(
+							'src' => mb_strpos($img_url, '://') !== FALSE
+								? $img_url
+								: URL::site($img_url, TRUE)
+						));
 					}
 				});
 


### PR DESCRIPTION
This is a follow-up after https://github.com/OpenBuildings/jam-tart/pull/22

`URL::site()` should not be used for images.

`URL::site()` will strip everything from the URL except the path string.

In general URLs to images should be configured in `config/jam.php`.
You could set the path prefix there as well as domain.

This is a workaround in `jam-tart` itself to sustain backwards compatibility.
