### PR TITLE
Fix the label of the date field in the filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: php
 
+dist: trusty
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@ php:
   - 7.0
   - hhvm
 
+matrix:
+  include:
+    - php: "5.3"
+      dist: precise
+
 branches:
   only:
     - master

--- a/classes/Kohana/Tart/Filter/Entry/Date.php
+++ b/classes/Kohana/Tart/Filter/Entry/Date.php
@@ -11,7 +11,9 @@ abstract class Kohana_Tart_Filter_Entry_Date extends Tart_Filter_Entry {
 
 	public function render()
 	{
-		return $this->parent()->form()->row('input', $this->name(), array(), array('type' => 'date', 'tabindex' => $this->tabindex()));
+		return $this->parent()->form()->row('input', $this->name(), array(
+		    'label' => $this->label(),
+        ), array('type' => 'date', 'tabindex' => $this->tabindex()));
 	}
 
 	public function default_callback()


### PR DESCRIPTION
Fix bug displaying humanized label, instead of specified label via `->label("Label text")`

For example the date filter field in the code below:
* Before the fix was displaying `Created at` from humanized `'created_at'`, which is incorrect. 
* After the fix is displaying `Create date` provided via `->label("Create date")`, which is correct.

```php
        $filter = Tart::filter($this->request->query())
            ->entries([
                'created_at' => Tart::entry('date', null, function ($collection, $value) {
                    return $collection->where('...');
                })->label('Created date'),
            ]);
```
