### PR TITLE
Fix JS error in console - check if href attribute is present

### DIFF
--- a/web/js/general.js
+++ b/web/js/general.js
@@ -93,13 +93,17 @@ $(function(){
 
 	$('body').on('click', '[data-toggle="modal"]', function(e) {
 		e.preventDefault();
-		var url = $(this).attr('href');
-		if (url.indexOf('#') === 0) {
-			$(url).modal('open');
-		} else {
-			$.get(url, function(data) {
-				$('<div class="modal hide fade">' + data + '</div>').modal();
-			}).success(function() { $('input:text:visible:first').focus(); });
+		const url = $(this).attr('href');
+		if (typeof url !== typeof undefined) {
+			if (url.indexOf('#') === 0) {
+				$(url).modal('open');
+			} else {
+				$.get(url, function (data) {
+					$('<div class="modal hide fade">' + data + '</div>').modal();
+				}).success(function () {
+					$('input:text:visible:first').focus();
+				});
+			}
 		}
 	});
 	


### PR DESCRIPTION
Currently, if you don't provide a `href` attribute for the modal, it will cause JS error in the browser console.

`general.js:97 Uncaught TypeError: Cannot read property 'indexOf' of undefined at HTMLButtonElement.<anonymous> (general.js:97)`

The solution is to check if the attribute is present.